### PR TITLE
Api renewals

### DIFF
--- a/src/ContextFreeTasks.Shared/AsyncContextFreeTaskMethodBuilder.cs
+++ b/src/ContextFreeTasks.Shared/AsyncContextFreeTaskMethodBuilder.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
 
-namespace ContextFreeTasks
+namespace ContextFreeTasks.Internal
 {
     [StructLayout(LayoutKind.Auto)]
     public struct AsyncContextFreeTaskMethodBuilder

--- a/src/ContextFreeTasks.Shared/AsyncContextFreeTaskMethodBuilder_T.cs
+++ b/src/ContextFreeTasks.Shared/AsyncContextFreeTaskMethodBuilder_T.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
 
-namespace ContextFreeTasks
+namespace ContextFreeTasks.Internal
 {
     [StructLayout(LayoutKind.Auto)]
     public struct AsyncContextFreeTaskMethodBuilder<T>

--- a/src/ContextFreeTasks.Shared/AsyncMethodBuilderAttribute.cs
+++ b/src/ContextFreeTasks.Shared/AsyncMethodBuilderAttribute.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Delegate | AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
-    public sealed class AsyncMethodBuilderAttribute : Attribute
+    internal sealed class AsyncMethodBuilderAttribute : Attribute
     {
         public AsyncMethodBuilderAttribute(Type builderType) => BuilderType = builderType;
         public Type BuilderType { get; }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask.cs
@@ -13,6 +13,6 @@ namespace ContextFreeTasks
         internal ContextFreeTask(Task t) => _task = t;
         public ContextFreeTaskAwaiter GetAwaiter() => new ContextFreeTaskAwaiter(Task);
         public void Wait() => _task?.Wait();
-        public ConfiguredTaskAwaitable EnableContextCapture() => Task.ConfigureAwait(true);
+        public ConfiguredTaskAwaitable ConfigureAwait(bool continueOnCapturedContext) => Task.ConfigureAwait(continueOnCapturedContext);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask.cs
@@ -12,5 +12,6 @@ namespace ContextFreeTasks
         internal ContextFreeTask(Task t) => _task = t;
         public ContextFreeTaskAwaiter GetAwaiter() => new ContextFreeTaskAwaiter(Task);
         public void Wait() => _task?.Wait();
+        public ConfiguredTaskAwaitable ConfigureAwait(bool continueOnCapturedContext) => Task.ConfigureAwait(continueOnCapturedContext);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask.cs
@@ -11,5 +11,6 @@ namespace ContextFreeTasks
         public Task Task => _task ?? FromResult(default(object));
         internal ContextFreeTask(Task t) => _task = t;
         public ContextFreeTaskAwaiter GetAwaiter() => new ContextFreeTaskAwaiter(Task);
+        public void Wait() => _task?.Wait();
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using ContextFreeTasks.Internal;
 using static System.Threading.Tasks.Task;
 
 namespace ContextFreeTasks

--- a/src/ContextFreeTasks.Shared/ContextFreeTask.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask.cs
@@ -7,7 +7,7 @@ namespace ContextFreeTasks
     public struct ContextFreeTask
     {
         public Task Task { get; }
-        public ContextFreeTask(Task t) => Task = t;
+        internal ContextFreeTask(Task t) => Task = t;
         public ContextFreeTaskAwaiter GetAwaiter() => new ContextFreeTaskAwaiter(Task);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask.cs
@@ -1,13 +1,15 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using static System.Threading.Tasks.Task;
 
 namespace ContextFreeTasks
 {
     [AsyncMethodBuilder(typeof(AsyncContextFreeTaskMethodBuilder))]
     public struct ContextFreeTask
     {
-        public Task Task { get; }
-        internal ContextFreeTask(Task t) => Task = t;
+        private readonly Task _task;
+        public Task Task => _task ?? FromResult(default(object));
+        internal ContextFreeTask(Task t) => _task = t;
         public ContextFreeTaskAwaiter GetAwaiter() => new ContextFreeTaskAwaiter(Task);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask.cs
@@ -12,6 +12,6 @@ namespace ContextFreeTasks
         internal ContextFreeTask(Task t) => _task = t;
         public ContextFreeTaskAwaiter GetAwaiter() => new ContextFreeTaskAwaiter(Task);
         public void Wait() => _task?.Wait();
-        public ConfiguredTaskAwaitable ConfigureAwait(bool continueOnCapturedContext) => Task.ConfigureAwait(continueOnCapturedContext);
+        public ConfiguredTaskAwaitable EnableContextCapture() => Task.ConfigureAwait(true);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTaskAwaiter.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTaskAwaiter.cs
@@ -7,7 +7,7 @@ namespace ContextFreeTasks
     public struct ContextFreeTaskAwaiter : ICriticalNotifyCompletion
     {
         private readonly Task _value;
-        internal ContextFreeTaskAwaiter(Task value) { _value = value; }
+        internal ContextFreeTaskAwaiter(Task value) => _value = value;
         public bool IsCompleted => _value.IsCompleted;
         public void GetResult() => _value.GetAwaiter().GetResult();
         public void OnCompleted(Action continuation) => _value.ConfigureAwait(false).GetAwaiter().OnCompleted(continuation);

--- a/src/ContextFreeTasks.Shared/ContextFreeTaskAwaiter.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTaskAwaiter.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-namespace ContextFreeTasks
+namespace ContextFreeTasks.Internal
 {
     public struct ContextFreeTaskAwaiter : ICriticalNotifyCompletion
     {

--- a/src/ContextFreeTasks.Shared/ContextFreeTaskAwaiter_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTaskAwaiter_T.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-namespace ContextFreeTasks
+namespace ContextFreeTasks.Internal
 {
     public struct ContextFreeTaskAwaiter<T> : ICriticalNotifyCompletion
     {

--- a/src/ContextFreeTasks.Shared/ContextFreeTaskAwaiter_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTaskAwaiter_T.cs
@@ -7,7 +7,7 @@ namespace ContextFreeTasks
     public struct ContextFreeTaskAwaiter<T> : ICriticalNotifyCompletion
     {
         private readonly Task<T> _value;
-        internal ContextFreeTaskAwaiter(Task<T> value) { _value = value; }
+        internal ContextFreeTaskAwaiter(Task<T> value) => _value = value;
         public bool IsCompleted => _value.IsCompleted;
         public T GetResult() => _value.GetAwaiter().GetResult();
         public void OnCompleted(Action continuation) => _value.ConfigureAwait(false).GetAwaiter().OnCompleted(continuation);

--- a/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
@@ -7,7 +7,7 @@ namespace ContextFreeTasks
     public struct ContextFreeTask<T>
     {
         public Task<T> Task { get; }
-        public ContextFreeTask(Task<T> t) => Task = t;
+        internal ContextFreeTask(Task<T> t) => Task = t;
         public ContextFreeTaskAwaiter<T> GetAwaiter() => new ContextFreeTaskAwaiter<T>(Task);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
@@ -9,7 +9,9 @@ namespace ContextFreeTasks
     {
         private readonly Task<T> _task;
         public Task<T> Task => _task ?? FromResult(default(T));
+        public T Result => GetAwaiter().GetResult();
         internal ContextFreeTask(Task<T> t) => _task = t;
         public ContextFreeTaskAwaiter<T> GetAwaiter() => new ContextFreeTaskAwaiter<T>(Task);
+        public void Wait() => _task?.Wait();
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
@@ -13,6 +13,6 @@ namespace ContextFreeTasks
         internal ContextFreeTask(Task<T> t) => _task = t;
         public ContextFreeTaskAwaiter<T> GetAwaiter() => new ContextFreeTaskAwaiter<T>(Task);
         public void Wait() => _task?.Wait();
-        public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext) => Task.ConfigureAwait(continueOnCapturedContext);
+        public ConfiguredTaskAwaitable<T> EnableContextCapture() => Task.ConfigureAwait(true);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
@@ -13,5 +13,6 @@ namespace ContextFreeTasks
         internal ContextFreeTask(Task<T> t) => _task = t;
         public ContextFreeTaskAwaiter<T> GetAwaiter() => new ContextFreeTaskAwaiter<T>(Task);
         public void Wait() => _task?.Wait();
+        public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext) => Task.ConfigureAwait(continueOnCapturedContext);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using ContextFreeTasks.Internal;
 using static System.Threading.Tasks.Task;
 
 namespace ContextFreeTasks

--- a/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
@@ -14,6 +14,6 @@ namespace ContextFreeTasks
         internal ContextFreeTask(Task<T> t) => _task = t;
         public ContextFreeTaskAwaiter<T> GetAwaiter() => new ContextFreeTaskAwaiter<T>(Task);
         public void Wait() => _task?.Wait();
-        public ConfiguredTaskAwaitable<T> EnableContextCapture() => Task.ConfigureAwait(true);
+        public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext) => Task.ConfigureAwait(continueOnCapturedContext);
     }
 }

--- a/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
+++ b/src/ContextFreeTasks.Shared/ContextFreeTask_T.cs
@@ -1,13 +1,15 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using static System.Threading.Tasks.Task;
 
 namespace ContextFreeTasks
 {
     [AsyncMethodBuilder(typeof(AsyncContextFreeTaskMethodBuilder<>))]
     public struct ContextFreeTask<T>
     {
-        public Task<T> Task { get; }
-        internal ContextFreeTask(Task<T> t) => Task = t;
+        private readonly Task<T> _task;
+        public Task<T> Task => _task ?? FromResult(default(T));
+        internal ContextFreeTask(Task<T> t) => _task = t;
         public ContextFreeTaskAwaiter<T> GetAwaiter() => new ContextFreeTaskAwaiter<T>(Task);
     }
 }

--- a/tests/UnitTestNet45/UnitTest1.cs
+++ b/tests/UnitTestNet45/UnitTest1.cs
@@ -1,6 +1,6 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ContextFreeTasks;
 using System.Threading.Tasks;
+using ContextFreeTasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTest
 {


### PR DESCRIPTION
the async method that returns `ContextFreeTask` means,

* it is declaring "I will not hold the context".
* it can 'Blocking-Wait' safely.
* It is not be null.

i changed:

* constructor makes to internal
* if created by `default` keyword, it behaves same as `FromResult(default(T))`
* add `Wait` method for blocking-wait
* add `EnableContextCapture` method for context propagation
* namespace restructuring