### PR TITLE
the 'true context-free'

### DIFF
--- a/src/ContextFreeTasks.Shared/Internal/AsyncContextFreeTaskMethodBuilder.cs
+++ b/src/ContextFreeTasks.Shared/Internal/AsyncContextFreeTaskMethodBuilder.cs
@@ -12,7 +12,20 @@ namespace ContextFreeTasks.Internal
         private AsyncTaskMethodBuilder _methodBuilder;
         public static AsyncContextFreeTaskMethodBuilder Create() =>
             new AsyncContextFreeTaskMethodBuilder() { _methodBuilder = AsyncTaskMethodBuilder.Create() };
-        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine => _methodBuilder.Start(ref stateMachine);
+        public void Start<TStateMachine>(ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine
+        {
+            var prevContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                _methodBuilder.Start(ref stateMachine);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(prevContext);
+            }
+        }
         public void SetStateMachine(IAsyncStateMachine stateMachine) => _methodBuilder.SetStateMachine(stateMachine);
         public void SetResult() => _methodBuilder.SetResult();
         public void SetException(Exception exception) => _methodBuilder.SetException(exception);

--- a/src/ContextFreeTasks.Shared/Internal/AsyncContextFreeTaskMethodBuilder_T.cs
+++ b/src/ContextFreeTasks.Shared/Internal/AsyncContextFreeTaskMethodBuilder_T.cs
@@ -12,7 +12,20 @@ namespace ContextFreeTasks.Internal
         private AsyncTaskMethodBuilder<T> _methodBuilder;
         public static AsyncContextFreeTaskMethodBuilder<T> Create() =>
             new AsyncContextFreeTaskMethodBuilder<T>() { _methodBuilder = AsyncTaskMethodBuilder<T>.Create() };
-        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine => _methodBuilder.Start(ref stateMachine);
+        public void Start<TStateMachine>(ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine
+        {
+            var prevContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                _methodBuilder.Start(ref stateMachine);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(prevContext);
+            }
+        }
         public void SetStateMachine(IAsyncStateMachine stateMachine) => _methodBuilder.SetStateMachine(stateMachine);
         public void SetResult(T result) => _methodBuilder.SetResult(result);
         public void SetException(Exception exception) => _methodBuilder.SetException(exception);


### PR DESCRIPTION
now `ContextFreeTask` is emulating all awaiter will be configured `ConfigureAwait(false)`.
but, unfortunately, `ConfigureAwait(false)` is not fully freed from context.
it declares "captures context, but not used.", to be exact.
the First awaiter can get caller's context, recursively.
causes deadlock by this scenario:
```csharp
void Main()
{
	SynchronizationContext.SetSynchronizationContext(new System.Windows.Forms.WindowsFormsSynchronizationContext());
	AsyncMethod1().Wait();
	Console.WriteLine("not reached!");
}
async Task AsyncMethod1() => await AsyncMethod2().ConfigureAwait(false);
async Task AsyncMethod2() => await UglyLibraryMethod().ConfigureAwait(false);
async Task UglyLibraryMethod() => await Task.Delay(1000); // not configured
```
this is, the `Task`'s limit.

However, `ContextFreeTask` doesn't!
Discard `SynchronizationContext` when start `AsyncStateMachine`, this problem can be avoided!
this pr has a breaking-change. but only hits wrong usage, and what is a better behavior, in any case.

this is the true ContextFreeTask.
