### PR TITLE
Removed unused and nonexistent references

### DIFF
--- a/tests/UnitTestNet45/UnitTestNet45.csproj
+++ b/tests/UnitTestNet45/UnitTestNet45.csproj
@@ -12,11 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\TaskLibrary\src\TaskLibraries\SystemAsync\SystemAsync.csproj" />
     <ProjectReference Include="..\..\src\ContextFreeTasks\ContextFreeTasks.csproj" />
-    <ProjectReference Include="..\GeneratedCommon.ViewModels\GeneratedCommon.ViewModels.csproj" />
-    <ProjectReference Include="..\GeneratedCommon\GeneratedCommon.csproj" />
-    <ProjectReference Include="..\Samples\V2\SampleTypes\SampleTypes\SampleTypes.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed references to projects that don't exist and that aren't required from the unit test project that were causing the build to fail.